### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/assignament1/LinkedList.py
+++ b/assignament1/LinkedList.py
@@ -130,8 +130,8 @@ class LinkedList(collections.MutableSet):
         String Conversion representation of object LinkeList repr()
         '''
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
+            return '{0!s}()'.format(self.__class__.__name__)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, list(self))
 
     def __eq__(self, other):
         '''

--- a/assignament1/mean_std.py
+++ b/assignament1/mean_std.py
@@ -47,7 +47,7 @@ def Mean(dataset):
     Summatory=fsum(dataset)
     Length=len(dataset)
     Mean=Summatory/Length
-    log.info("The Mean of dataset is %s" % Mean)
+    log.info("The Mean of dataset is {0!s}".format(Mean))
     return Mean
 
 def Std(dataset):
@@ -58,7 +58,7 @@ def Std(dataset):
     LengthMinusOne=len(dataset)-1
     CurrentMean=Mean(dataset)
     Std=sqrt(sum([(data - CurrentMean)**2 for data in dataset]) / LengthMinusOne)
-    log.info("The Std of dataset is %s" % Std)
+    log.info("The Std of dataset is {0!s}".format(Std))
     return Std
 
 def read_file(file):
@@ -78,7 +78,7 @@ def read_file(file):
                     try:
                         dataset.add(float(row[0]))
                     except ValueError:
-                        log.warning("%s Is not a float" % row[0])
+                        log.warning("{0!s} Is not a float".format(row[0]))
                 else:
                     log.warning("Empty Row")
         return dataset

--- a/assignament1/test_mean_std.py
+++ b/assignament1/test_mean_std.py
@@ -7,16 +7,16 @@ class TestAssignament(unittest.TestCase):
         print "---------------------------------------"
         print "In method", self._testMethodName
         print a
-        print("%.2f" % Mean(a))
-        print("%.2f" % Std(a))
+        print("{0:.2f}".format(Mean(a)))
+        print("{0:.2f}".format(Std(a)))
     
     def test_development_hours(self):
         print "---------------------------------------"
         print "In method", self._testMethodName
         a=LinkedList([15.0,69.9,6.5,22.4,28.4,65.9,19.4,198.7,38.8,138.2])
         print a
-        print("%.2f" % Mean(a))
-        print("%.2f" % Std(a))
+        print("{0:.2f}".format(Mean(a)))
+        print("{0:.2f}".format(Std(a)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/assignament2/pyloc.py
+++ b/assignament2/pyloc.py
@@ -123,17 +123,17 @@ def LOCCountDir(root, extensions=PY_EXTENSION):
     while True:
         try:
             file_to_count = locate.next()
-            log.info("Counting File: %s" % file_to_count)
+            log.info("Counting File: {0!s}".format(file_to_count))
             (code_lines, parts, total_lines, blank_lines, comment_lines)=LOCCountFile(file_to_count)
             #print "===================================================================="
-            print string.expandtabs("\t%s" % file_to_count.split("/")[-1],16)
+            print string.expandtabs("\t{0!s}".format(file_to_count.split("/")[-1]),16)
             FormatOutput(code_lines, parts, total_lines, blank_lines, comment_lines)
             great_total+=code_lines
         except StopIteration:
             log.info("Fin De Archivado")
             break
     print "===================================================================="
-    print string.expandtabs("TOTAL\t\t\t%s" % great_total,16)
+    print string.expandtabs("TOTAL\t\t\t{0!s}".format(great_total),16)
     print "===================================================================="
             
 
@@ -172,17 +172,17 @@ def LOCCountFile(file):
             
     with open(file, 'rb') as code_file:
         for line in code_file:
-            log.debug("RUNINGPART:%s  INPART:%s" % (running_part, in_part))
+            log.debug("RUNINGPART:{0!s}  INPART:{1!s}".format(running_part, in_part))
             total_lines+=1
             if line.strip().startswith("#"):
                 comment_lines+=1
-                log.debug("COMENT LINE %s %s" % (comment_lines, line))
+                log.debug("COMENT LINE {0!s} {1!s}".format(comment_lines, line))
             elif not line.strip():
                 blank_lines+=1
-                log.debug("BLANK LINE %s %s" % (blank_lines, line))
+                log.debug("BLANK LINE {0!s} {1!s}".format(blank_lines, line))
             else:
                 code_lines+=1
-                log.debug("CODE LINE %s %s" % (code_lines, line))
+                log.debug("CODE LINE {0!s} {1!s}".format(code_lines, line))
                 running_item=Item(line, total_lines)
                 if running_item.is_a_part:
                     if running_item.ident_level==0:
@@ -191,24 +191,24 @@ def LOCCountFile(file):
                         running_part=running_item.name
                         parts[running_part].length+=1
                         in_part=True
-                        logpart=logging.getLogger('LOC.%s' % running_part)
-                        log.debug("ADDED PART %s %s" % (running_item.name, 
+                        logpart=logging.getLogger('LOC.{0!s}'.format(running_part))
+                        log.debug("ADDED PART {0!s} {1!s}".format(running_item.name, 
                                                                         line))
                     elif running_item.ident_level==1:
                         parts[running_part].sub_items[running_item.name]=running_item
                         parts[running_part].length+=1
-                        logpart.debug("IN PART %s  ADD ITEM %s: %s" % (running_part, 
+                        logpart.debug("IN PART {0!s}  ADD ITEM {1!s}: {2!s}".format(running_part, 
                                                     running_item.name, line))
                     else:
                         parts[running_part].length+=1
-                        logpart.debug("PART LENGTH %s: %s %s" % (running_part, 
+                        logpart.debug("PART LENGTH {0!s}: {1!s} {2!s}".format(running_part, 
                                             parts[running_part].length, line))
                 else:
                     if in_part:
-                        logpart.debug("IDENT: %s" % running_item.ident_level)
+                        logpart.debug("IDENT: {0!s}".format(running_item.ident_level))
                         if running_item.ident_level>0:
                             parts[running_part].length+=1
-                            logpart.debug("PART LENGTH %s: %s" % (running_part, 
+                            logpart.debug("PART LENGTH {0!s}: {1!s}".format(running_part, 
                                             parts[running_part].length))
                         else:
                             parts[running_part].end_line=total_lines
@@ -243,9 +243,9 @@ def FormatOutput(code_lines, parts, total_lines=0, blank_lines=0, comment_lines=
     for part in parts:
         if len(parts[part].sub_items.keys())==0:
             parts[part].sub_items[None]=None
-        print string.expandtabs("%s\t%s\t%s" % (parts[part].name, 
+        print string.expandtabs("{0!s}\t{1!s}\t{2!s}".format(parts[part].name, 
                     len(parts[part].sub_items.keys()), parts[part].length),16)
-    print string.expandtabs("\t\t\t%s" % code_lines,16)
+    print string.expandtabs("\t\t\t{0!s}".format(code_lines),16)
 
 
 def main():

--- a/assignament3/LinkedList.py
+++ b/assignament3/LinkedList.py
@@ -130,8 +130,8 @@ class LinkedList(collections.MutableSet):
         String Conversion representation of object LinkeList repr()
         '''
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
+            return '{0!s}()'.format(self.__class__.__name__)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, list(self))
 
     def __eq__(self, other):
         '''

--- a/assignament3/fit.py
+++ b/assignament3/fit.py
@@ -68,7 +68,7 @@ def read_file(file):
                     try:
                         dataset.add(( float(row[0]) , float(row[1]) ))
                     except ValueError:
-                        log.warning("%s Problem whit row" % row[0])
+                        log.warning("{0!s} Problem whit row".format(row[0]))
                 else:
                     #mesnsaje: row whit insuficient data.
                     log.warning("row whit insuficient data or Empty Row")
@@ -280,14 +280,13 @@ def FormatOutput(beta_zero, beta_one,
                                                                              16)
     print "===================================================================="
     #Print Values
-    print string.expandtabs("%s\t%s\t%s\t%s" % (
-                            beta_zero,beta_one,
-                            correlation_r,correlation_square_r)
+    print string.expandtabs("{0!s}\t{1!s}\t{2!s}\t{3!s}".format(
+                            beta_zero, beta_one,
+                            correlation_r, correlation_square_r)
                             ,16)
     print "===================================================================="
     if estimated_proxy_size and prediction:
-        print ("For E=%s The prediction is P=%s" % 
-                                             (estimated_proxy_size, prediction))
+        print ("For E={0!s} The prediction is P={1!s}".format(estimated_proxy_size, prediction))
 
 #main
 def main():

--- a/assignament4/mean_std.py
+++ b/assignament4/mean_std.py
@@ -47,7 +47,7 @@ def Mean(dataset):
     Summatory=fsum(dataset)
     Length=len(dataset)
     Mean=Summatory/Length
-    log.info("The Mean of dataset is %s" % Mean)
+    log.info("The Mean of dataset is {0!s}".format(Mean))
     return Mean
 
 def Std(dataset):
@@ -58,7 +58,7 @@ def Std(dataset):
     LengthMinusOne=len(dataset)-1
     CurrentMean=Mean(dataset)
     Std=sqrt(sum([(data - CurrentMean)**2 for data in dataset]) / LengthMinusOne)
-    log.info("The Std of dataset is %s" % Std)
+    log.info("The Std of dataset is {0!s}".format(Std))
     return Std
 
 def read_file(file):
@@ -78,7 +78,7 @@ def read_file(file):
                     try:
                         dataset.add(float(row[0]))
                     except ValueError:
-                        log.warning("%s Is not a float" % row[0])
+                        log.warning("{0!s} Is not a float".format(row[0]))
                 else:
                     log.warning("Empty Row")
         return dataset

--- a/assignament4/proxy_estimated_table_size.py
+++ b/assignament4/proxy_estimated_table_size.py
@@ -85,7 +85,7 @@ class Parts(object):
         try:
             self.loc_methods = self.loc / self.n_of_items
         except ZeroDivisionError:
-            log.warning("Number of for part %s items is Zero" % (self.name) )
+            log.warning("Number of for part {0!s} items is Zero".format((self.name)) )
             self.loc_methods = 0
         return self.loc_methods
 
@@ -205,7 +205,7 @@ def read_file(file):
                         parts.append(Parts(name=row[0],
                             loc=float(row[1]), n_of_items=float(row[2])))
                     except ValueError:
-                        log.warning("%s Problem whit row" % row)
+                        log.warning("{0!s} Problem whit row".format(row))
                 else:
                     #mesnsaje: row whit insuficient data.
                     log.warning("row whit insuficient data or Empty Row")
@@ -234,7 +234,7 @@ def FormatOutput(vs, s, m, l, vl):
     print string.expandtabs("VS\tS\tM\tL\tVL", 16)
     print "===================================================================="
     #Print Values
-    print string.expandtabs("%s\t%s\t%s\t%s\t%s" % (vs, s, m, l, vl), 16)
+    print string.expandtabs("{0!s}\t{1!s}\t{2!s}\t{3!s}\t{4!s}".format(vs, s, m, l, vl), 16)
     print "===================================================================="
 
 #main

--- a/assignament5/proxy_estimated_table_size.py
+++ b/assignament5/proxy_estimated_table_size.py
@@ -85,7 +85,7 @@ class Parts(object):
         try:
             self.loc_methods = self.loc / self.n_of_items
         except ZeroDivisionError:
-            log.warning("Number of for part %s items is Zero" % (self.name) )
+            log.warning("Number of for part {0!s} items is Zero".format((self.name)) )
             self.loc_methods = 0
         return self.loc_methods
 
@@ -205,7 +205,7 @@ def read_file(file):
                         parts.append(Parts(name=row[0],
                             loc=float(row[1]), n_of_items=float(row[2])))
                     except ValueError:
-                        log.warning("%s Problem whit row" % row)
+                        log.warning("{0!s} Problem whit row".format(row))
                 else:
                     #mesnsaje: row whit insuficient data.
                     log.warning("row whit insuficient data or Empty Row")
@@ -234,7 +234,7 @@ def FormatOutput(vs, s, m, l, vl):
     print string.expandtabs("VS\tS\tM\tL\tVL", 16)
     print "===================================================================="
     #Print Values
-    print string.expandtabs("%s\t%s\t%s\t%s\t%s" % (vs, s, m, l, vl), 16)
+    print string.expandtabs("{0!s}\t{1!s}\t{2!s}\t{3!s}\t{4!s}".format(vs, s, m, l, vl), 16)
     print "===================================================================="
 
 #main


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:arpagon:assignaments?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:arpagon:assignaments?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
